### PR TITLE
HTTP errors being ignored

### DIFF
--- a/main.js
+++ b/main.js
@@ -81,6 +81,7 @@ var AmazonSES = (function() {
     };
 
     request(options, function(error, response, body) {
+      if (error) return opts.callback(error);
       var parser = new xml.Parser();
       parser.addListener('end', function(data) {
         var err = null;


### PR DESCRIPTION
All SES methods currently ignore HTTP errors, crushing the entire application when one occurs.
