### PR TITLE
Add the ability to specify AWS host by region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/main.js
+++ b/main.js
@@ -43,6 +43,7 @@ var AmazonSES = (function() {
       , 'Message.Body.Html.Data': opts.body.html
       , 'Message.Body.Html.Charset': 'UTF-8'
       , 'Message.Subject.Data' : opts.subject
+      , 'host' : opts.host
     };
     _.extend(params, getDestinationList(opts.to, 'To'));
     _.extend(params, getDestinationList(opts.cc, 'Cc'));
@@ -53,8 +54,16 @@ var AmazonSES = (function() {
   };
 
   var call = function(opts) {
-    var host = 'email.us-east-1.amazonaws.com';
+    var host = AmazonSES.regions.US_East;
     var path = '/';
+
+    // Assumed opts.host is a value in AmazonSES.regions
+    // as defined at the bottom of main.js
+
+    if (opts.query.hasOwnProperty("host")) {
+        host = opts.query.host;
+        delete opts.query.host;
+    }
 
     var now = (new Date()).toUTCString();
     var body = qs.stringify(opts.query);
@@ -220,4 +229,12 @@ var AmazonSES = (function() {
   return Constructor;
 
 }());
+
+// Different AWS region endpoints
+AmazonSES.regions = {
+  US_East: 'email.us-east-1.amazonaws.com',
+  US_West: 'email.us-west-2.amazonaws.com',
+  EU: 'email.eu-west-1.amazonaws.com'
+};
+
 module.exports = AmazonSES;


### PR DESCRIPTION
For our use case, at Seattle University, we've only been approved by AWS to send emails from the US West (Oregon) region. Previously, the hard-coded value was set to the US East (North Virginia) region so we couldn't use this library.

I've left the default to US East for the sake of not breaking backwards compatibility :smiley: 
